### PR TITLE
Fix typo, correspoding -> corresponding

### DIFF
--- a/zhlipsum.dtx
+++ b/zhlipsum.dtx
@@ -424,7 +424,7 @@ Copyright (C) 2017&ndash;2022 by Xiangdong Zeng <xdzeng96@gmail.com>.
 % 而本宏包中所有选项均为小写。
 %^^A! If you have loaded \CTeX{} bundle, then the encoding will be
 %^^A! selected automatically according to \CTeX{}. Note that in \CTeX{}
-%^^A! bundle, the correspoding options are \opt{UTF8} and \opt{GBK},
+%^^A! bundle, the corresponding options are \opt{UTF8} and \opt{GBK},
 %^^A! while the options in \pkg{zhlipsum} are all in \emph{lowercase}.
 %^^A!
 %


### PR DESCRIPTION
Found via `codespell -H -L ot`